### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,8 +39,15 @@ async def create_questions(file: UploadFile):
     Returns:
         str: The generated interview questions.
     """
-    answers = question_maker.create_questions(file.file)
-    return answers
+    try:
+        answers = question_maker.create_questions(file.file)
+        return answers
+    except Exception as e:
+        # Log the detailed error message
+        import logging
+        logging.error("Error occurred while creating questions: %s", str(e))
+        # Return a generic error message to the user
+        return {"error": "An internal error occurred. Please try again later."}
 
 static = FastAPI()
 static.mount('', StaticFiles(directory="./site/build",


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/CVQuest/security/code-scanning/1](https://github.com/venkateshpabbati/CVQuest/security/code-scanning/1)

To fix the issue, we need to ensure that the `create_questions` endpoint in `main.py` does not directly return the result of `question_maker.create_questions(file.file)` when an error occurs. Instead, we should catch any exceptions raised during the process, log the detailed error message on the server, and return a generic error message to the user. This approach prevents sensitive information from being exposed while still allowing developers to debug issues using the server logs.

The changes involve:
1. Wrapping the call to `question_maker.create_questions` in a `try-except` block in `main.py`.
2. Logging the detailed error message using a logging library (e.g., Python's built-in `logging` module).
3. Returning a generic error message (e.g., "An internal error occurred. Please try again later.") to the user.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
